### PR TITLE
Replace Travis with GitHub Actions + Fix Tests

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1,0 +1,27 @@
+name: Build package
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+      - name: Install dependencies
+        run: npm install
+      - name: Lint
+        run: npm run lint
+      - name: Build
+        run: npm run transpile
+      - name: Package
+        run: npm pack
+      - name: Upload
+        uses: actions/upload-artifact@v2
+        with:
+            name: package
+            path: "*.tgz"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,15 @@
+name: Test
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Run tests using docker-compose
+        run: docker-compose run --rm sut

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,0 @@
-language: bash
-
-script:
-  - docker-compose run --rm sut
-
-services:
-  - docker

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,79 +1,78 @@
-sut:
-  image: node:16
-  command: sh -c 'npm install && npm test'
-  volumes:
-    - .:/app
-  environment:
-    - CI=true
-  links:
-    - bitcoin-core
-    - bitcoin-core-multi-wallet
-    - bitcoin-core-ssl
-    - bitcoin-core-username-only
-  working_dir: /app
+version: "3"
 
-bitcoin-core:
-  image: ruimarinho/bitcoin-core:22.0-alpine
-  command: -printtoconsole
-    -regtest=1
-    -rest
-    -rpcallowip=10.211.0.0/16
-    -rpcallowip=172.17.0.0/16
-    -rpcallowip=192.168.0.0/16
-    -rpcpassword=bar
-    -rpcport=18443
-    -rpcuser=foo
-    -server
-  ports:
-    - 18443:18443
+services:
+  sut:
+    image: node:16
+    command: sh -c 'npm install && npm run transpile && npm test'
+    volumes:
+      - .:/app
+    environment:
+      - CI=true
+    depends_on:
+      - bitcoin-core
+      - bitcoin-core-multi-wallet
+      - bitcoin-core-ssl
+      - bitcoin-core-username-only
+    working_dir: /app
 
-bitcoin-core-multi-wallet:
-  image: ruimarinho/bitcoin-core:22.0-alpine
-  command: -printtoconsole
-    -regtest=1
-    -rest
-    -rpcallowip=10.211.0.0/16
-    -rpcallowip=172.17.0.0/16
-    -rpcallowip=192.168.0.0/16
-    -rpcpassword=bar
-    -wallet=wallet1
-    -wallet=wallet2
-    -rpcport=18453
-    -rpcuser=foo
-    -server
-  ports:
-    - 18453:18453
+  bitcoin-core:
+    image: ruimarinho/bitcoin-core:0.17-alpine
+    command: -printtoconsole
+      -regtest=1
+      -rest
+      -rpcallowip=0.0.0.0/0
+      -rpcbind=0.0.0.0
+      -rpcpassword=bar
+      -rpcport=18443
+      -rpcuser=foo
+      -server
+    expose:
+      - 18443
 
-bitcoin-core-ssl:
-  image: ruimarinho/bitcoin-core:0.11-alpine
-  command: -printtoconsole
-    -regtest=1
-    -rest
-    -rpcallowip=10.211.0.0/16
-    -rpcallowip=172.17.0.0/16
-    -rpcallowip=192.168.0.0/16
-    -rpcpassword=bar
-    -rpcport=18463
-    -rpcssl
-    -rpcsslcertificatechainfile=/etc/ssl/bitcoind/cert.pem
-    -rpcsslprivatekeyfile=/etc/ssl/bitcoind/key.pem
-    -rpcuser=foo
-    -server
-  volumes:
-    - ./test/config/ssl:/etc/ssl/bitcoind
-  ports:
-    - 18463:18463
+  bitcoin-core-multi-wallet:
+    image: ruimarinho/bitcoin-core:0.17-alpine
+    command: -printtoconsole
+      -regtest=1
+      -rest
+      -rpcallowip=0.0.0.0/0
+      -rpcbind=0.0.0.0
+      -rpcpassword=bar
+      -wallet=wallet1
+      -wallet=wallet2
+      -rpcport=18453
+      -rpcuser=foo
+      -server
+    expose:
+      - 18453
 
-bitcoin-core-username-only:
-  image: ruimarinho/bitcoin-core:0.11-alpine
-  command: -printtoconsole
-    -regtest=1
-    -rest
-    -rpcallowip=10.211.0.0/16
-    -rpcallowip=172.17.0.0/16
-    -rpcallowip=192.168.0.0/16
-    -rpcport=18473
-    -rpcuser=foo
-    -server
-  ports:
-    - 18473:18473
+  bitcoin-core-ssl:
+    image: ruimarinho/bitcoin-core:0.11-alpine
+    command: -printtoconsole
+      -regtest=1
+      -rest
+      -rpcallowip=0.0.0.0/0
+      -rpcbind=0.0.0.0
+      -rpcpassword=bar
+      -rpcport=18463
+      -rpcssl
+      -rpcsslcertificatechainfile=/etc/ssl/bitcoind/cert.pem
+      -rpcsslprivatekeyfile=/etc/ssl/bitcoind/key.pem
+      -rpcuser=foo
+      -server
+    volumes:
+      - ./test/config/ssl:/etc/ssl/bitcoind
+    expose:
+      - 18463
+
+  bitcoin-core-username-only:
+    image: ruimarinho/bitcoin-core:0.11-alpine
+    command: -printtoconsole
+      -regtest=1
+      -rest
+      -rpcallowip=0.0.0.0/0
+      -rpcbind=0.0.0.0
+      -rpcport=18473
+      -rpcuser=foo
+      -server
+    expose:
+      - 18473

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,5 @@
 sut:
-  image: node:4
+  image: node:16
   command: sh -c 'npm install && npm test'
   volumes:
     - .:/app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ sut:
   working_dir: /app
 
 bitcoin-core:
-  image: ruimarinho/bitcoin-core:0.17-alpine
+  image: ruimarinho/bitcoin-core:22.0-alpine
   command: -printtoconsole
     -regtest=1
     -rest
@@ -28,7 +28,7 @@ bitcoin-core:
     - 18443:18443
 
 bitcoin-core-multi-wallet:
-  image: ruimarinho/bitcoin-core:0.17-alpine
+  image: ruimarinho/bitcoin-core:22.0-alpine
   command: -printtoconsole
     -regtest=1
     -rest

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "dependencies": "docker-compose up -d bitcoind bitcoind-ssl bitcoind-username-only",
     "lint": "eslint \"**/*.{ts,tsx}\"",
     "prepublish": "npm run transpile",
-    "test": "NODE_ENV=test mocha $npm_package_options_mocha",
+    "test": "NODE_ENV=test mocha --require @babel/register --require @babel/polyfill --timeout 20000 --recursive --require should",
     "testdocker": "docker-compose run --rm sut",
     "transpile": "rm -rf dist/* && tsc --project ./ && babel build --out-dir dist/src --copy-files",
     "version": "npm run changelog --future-release=$npm_package_version && npm run transpile && git add -A CHANGELOG.md dist"
@@ -83,9 +83,6 @@
     "instrument": false,
     "report-dir": "./coverage",
     "sourceMap": false
-  },
-  "options": {
-    "mocha": "--require @babel/register --require @babel/polyfill --timeout 20000 --recursive --require should"
   },
   "pre-commit": [
     "lint"

--- a/src/methods.ts
+++ b/src/methods.ts
@@ -685,7 +685,7 @@ export const methods: Methods = {
   },
   scantxoutset: {
     category: "blockchain",
-    version: new Range("=>0.17.0"),
+    version: new Range(">=0.17.0"),
   },
   sendFrom: {
     category: "wallet",

--- a/test/client_test.js
+++ b/test/client_test.js
@@ -2,12 +2,12 @@
  * Module dependencies.
  */
 
-import Client from "../src/index";
-import RpcError from "../src/errors/rpc-error";
+import Client from "../dist/src/index";
+import RpcError from "../dist/src/errors/rpc-error";
 import _ from "lodash";
 import config from "./config";
 import fs from "fs";
-import methods from "../src/methods";
+import methods from "../dist/src/methods";
 import parse from "./utils/help-parser-util";
 import path from "path";
 import should from "should";

--- a/test/errors/rpc-error_test.js
+++ b/test/errors/rpc-error_test.js
@@ -3,7 +3,7 @@
  */
 
 import { STATUS_CODES } from "http";
-import RpcError from "../../src/errors/rpc-error";
+import RpcError from "../../dist/src/errors/rpc-error";
 import should from "should";
 
 /**

--- a/test/logging/request-obfuscator_test.js
+++ b/test/logging/request-obfuscator_test.js
@@ -288,7 +288,7 @@ describe("RequestObfuscator", () => {
 
     it("should obfuscate the `body` when `headers.content-type` is `application/octet-stream`", () => {
       const request = {
-        body: new Buffer("foobar"),
+        body: Buffer.from("foobar"),
         headers: { "content-type": "application/octet-stream" },
         type: "response",
       };

--- a/test/logging/request-obfuscator_test.js
+++ b/test/logging/request-obfuscator_test.js
@@ -2,7 +2,7 @@
  * Module dependencies.
  */
 
-import { obfuscate } from "../../src/logging/request-obfuscator";
+import { obfuscate } from "../../dist/src/logging/request-obfuscator";
 
 /**
  * Test `RequestObfuscator`.

--- a/test/multi_wallet_test.js
+++ b/test/multi_wallet_test.js
@@ -3,8 +3,8 @@
  */
 
 import { defaults } from "lodash";
-import Client from "../src/index";
-import RpcError from "../src/errors/rpc-error";
+import Client from "../dist/src/index";
+import RpcError from "../dist/src/errors/rpc-error";
 import config from "./config";
 
 /**

--- a/test/parser_test.js
+++ b/test/parser_test.js
@@ -3,8 +3,8 @@
  */
 
 import { defaults } from "lodash";
-import Client from "../src/index";
-import RpcError from "../src/errors/rpc-error";
+import Client from "../dist/src/index";
+import RpcError from "../dist/src/errors/rpc-error";
 import config from "./config";
 import nock from "nock";
 import should from "should";

--- a/test/requester_test.js
+++ b/test/requester_test.js
@@ -3,7 +3,7 @@
  */
 
 import { defaults } from "lodash";
-import Client from "../src/index";
+import Client from "../dist/src/index";
 import config from "./config";
 import should from "should";
 

--- a/test/rest_test.js
+++ b/test/rest_test.js
@@ -2,8 +2,8 @@
  * Module dependencies.
  */
 
-import Client from "../src/index";
-import RpcError from "../src/errors/rpc-error";
+import Client from "../dist/src/index";
+import RpcError from "../dist/src/errors/rpc-error";
 import config from "./config";
 import should from "should";
 

--- a/test/single_wallet_test.js
+++ b/test/single_wallet_test.js
@@ -3,8 +3,8 @@
  */
 
 import { defaults } from "lodash";
-import Client from "../src/index";
-import RpcError from "../src/errors/rpc-error";
+import Client from "../dist/src/index";
+import RpcError from "../dist/src/errors/rpc-error";
 import config from "./config";
 
 /**


### PR DESCRIPTION
Closes #5

* Replaces `travis.yml` with two github actions in `.github/workflows`
  * `test.yml` is basically the same as what travis was doing, running the tests in `docker-compose`
  * `build.yml` lints, builds, and packages the npm package and exposes it as a build artifact
    * If you wanna get wild and crazy, we could have a third action automatically publish it, but I'll assume you wanna keep things manual for now.
* Fixes `docker-compose` configuration
  * Updates format to version 3
  * Fixes invalid `bitcoind` flags that caused RPC requests to be forbidden
  * Changes port exposure to be docker-internal only to avoid unnecessary port conflicts if ports were in use
  * Bumps node version to 16
* Changes test import paths to use `dist/src`
  * Alternatively we could rewrite the tests in `ts` and use `mocha-ts` but this is simpler for now
* Fixes invalid `test` command options
* (Unrelated, found in testing) Fixes an invalid semver definition